### PR TITLE
CleartextTraffic enabled needed in new android version to run properly

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:name="com.github.nkzawa.socketio.androidchat.ChatApplication"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/AppTheme" >
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <activity
             android:name="com.github.nkzawa.socketio.androidchat.MainActivity"
             android:label="@string/app_name" >


### PR DESCRIPTION
Recently y came to this repositoriy to learn how to use socket.io in a personal proyect and found that in the new version of android studio and java the proyect won't work unless you enable the cleartext traffic in the app manifest.